### PR TITLE
fix unmapping problem

### DIFF
--- a/clk.h
+++ b/clk.h
@@ -51,7 +51,7 @@ typedef struct {
 #define CM_PWM_DIV_PASSWD                        (0x5a << 24)
 #define CM_PWM_DIV_DIVI(val)                     ((val & 0xfff) << 12)
 #define CM_PWM_DIV_DIVF(val)                     ((val & 0xfff) << 0)
-} __attribute__ ((packed)) cm_pwm_t;
+} cm_pwm_t;
 
 
 #define CM_PWM_OFFSET                            (0x001010a0)

--- a/dma.h
+++ b/dma.h
@@ -46,7 +46,7 @@ typedef struct
     uint32_t stride;
     uint32_t nextconbk;
     uint32_t resvd_0x18[2];
-} __attribute__((packed)) dma_cb_t;
+} dma_cb_t;
 
 /*
  * DMA register set
@@ -95,7 +95,7 @@ typedef struct
 #define RPI_DMA_STRIDE_S_STRIDE(val)             ((val & 0xffff) << 0)
     uint32_t nextconbk;
     uint32_t debug;
-} __attribute__((packed)) dma_t;
+} dma_t;
 
 
 #define DMA0_OFFSET                              (0x00007000)

--- a/gpio.h
+++ b/gpio.h
@@ -59,7 +59,7 @@ typedef struct
     uint32_t pudclk[2];                          // GPIO Pin Pull up/down Enable Clock
     uint32_t resvd_0xa0[4];
     uint32_t test;
-} __attribute__((packed)) gpio_t;
+} gpio_t;
 
 
 #define GPIO_OFFSET                              (0x00200000)

--- a/pwm.h
+++ b/pwm.h
@@ -96,7 +96,7 @@ typedef struct
     uint32_t resvd_0x1c;
     uint32_t rng2;
     uint32_t dat2;
-} __attribute__((packed)) pwm_t;
+} pwm_t;
 
 
 #define PWM_OFFSET                               (0x0020c000)

--- a/ws2811.c
+++ b/ws2811.c
@@ -116,6 +116,24 @@ static int max_channel_led_count(ws2811_t *ws2811)
 }
 
 /**
+ * Unmap a physical address and length from virtual memory.
+ *
+ * @param    addr  Virtual address pointer of device registers.
+ * @param    len   Length of mapped region.
+ *
+ * @returns  None
+ */
+static void unmap_device(volatile void *addr, const uint32_t len)
+{
+    uint32_t virt = (uint32_t)addr;
+    uint32_t start_page_addr = virt & PAGE_MASK;
+    uint32_t end_page_addr = (virt + len) & PAGE_MASK;
+    uint32_t pages = end_page_addr - start_page_addr + 1;
+
+    munmap((void *)addr, PAGE_SIZE * pages);
+}
+
+/**
  * Map all devices into userspace memory.
  *
  * @param    ws2811  ws2811 instance pointer.
@@ -173,22 +191,22 @@ static void unmap_registers(ws2811_t *ws2811)
 
     if (device->dma)
     {
-        unmapmem((void *)device->dma, sizeof(dma_t));
+        unmap_device(device->dma, sizeof(dma_t));
     }
 
     if (device->pwm)
     {
-        unmapmem((void *)device->pwm, sizeof(pwm_t));
+        unmap_device(device->pwm, sizeof(pwm_t));
     }
 
     if (device->cm_pwm)
     {
-        unmapmem((void *)device->cm_pwm, sizeof(cm_pwm_t));
+        unmap_device(device->cm_pwm, sizeof(cm_pwm_t));
     }
 
     if (device->gpio)
     {
-        unmapmem((void *)device->gpio, sizeof(gpio_t));
+        unmap_device(device->gpio, sizeof(gpio_t));
     }
 }
 


### PR DESCRIPTION
As discussed in jgarff/rpi_ws281x#32 this patch solves an issue with memory unmapping. 

I have to admit I am not proficient enough in C to fully understand what the issue exactly is and why this solves it, but it would be great if we could have this in your fork - as it happens to be the upstream for raspberry-pi 2 compatibility.

Also: Thanks a lot for your work, it did save me a lot of trouble :)
